### PR TITLE
Use precommit env variables

### DIFF
--- a/docstring_validator/diff_util.py
+++ b/docstring_validator/diff_util.py
@@ -2,6 +2,7 @@
 
 Iterating over file system or git diff output are supported.
 """
+import os
 import re
 from pathlib import Path
 from typing import Generator, List, NamedTuple, Optional, Sequence, Union
@@ -108,3 +109,13 @@ def find_func_names(
         if matches:
             functions.append(matches.group(1))
     return functions
+
+
+def from_ref() -> Optional[str]:
+    """Retrieves user provided --from-ref."""
+    return os.environ.get("PRE_COMMIT_FROM_REF")
+
+
+def to_ref() -> Optional[str]:
+    """Retrieves user provided --to-ref."""
+    return os.environ.get("PRE_COMMIT_TO_REF")

--- a/docstring_validator/docstring_validator.py
+++ b/docstring_validator/docstring_validator.py
@@ -32,7 +32,9 @@ def analyze_staged(
     Returns:
         Text report from analysis
     """
-    generator = iter_diffs(Path(path), pattern=r"\.py$")
+    print(Path(path))
+    print(Path(path).resolve())
+    generator = iter_diffs(Path(path).resolve(), pattern=r"\.py$")
     return _analyze_files(generator, func_name_filter)
 
 

--- a/docstring_validator/docstring_validator.py
+++ b/docstring_validator/docstring_validator.py
@@ -2,8 +2,8 @@
 from pathlib import Path
 from typing import Dict, Generator, List, Optional, Union
 
+from docstring_validator import diff_util
 from docstring_validator.code_parser import get_docstring
-from docstring_validator.diff_util import find_func_names, iter_diffs, iter_files
 from docstring_validator.docstring_model import Docstring
 from docstring_validator.reporter import report_errors
 
@@ -32,9 +32,12 @@ def analyze_staged(
     Returns:
         Text report from analysis
     """
-    print(Path(path))
-    print(Path(path).resolve())
-    generator = iter_diffs(Path(path).resolve(), pattern=r"\.py$")
+    generator = diff_util.iter_diffs(
+        Path(path).resolve(),
+        pattern=r"\.py$",
+        baseline_rev=diff_util.from_ref(),
+        target_rev=diff_util.to_ref(),
+    )
     return _analyze_files(generator, func_name_filter)
 
 
@@ -65,7 +68,7 @@ def analyze_files(
     Returns:
         Text report from analysis
     """
-    generator = iter_files(path)
+    generator = diff_util.iter_files(path)
     return _analyze_files(generator, func_name_filter)
 
 
@@ -74,7 +77,7 @@ def _analyze_files(
 ) -> List[str]:
     errors = {}
     for file in generator:
-        func_names = find_func_names(file.content, func_name_filter)
+        func_names = diff_util.find_func_names(file.content, func_name_filter)
 
         file_errors = {}
         for func in func_names:

--- a/docstring_validator/docstring_validator.py
+++ b/docstring_validator/docstring_validator.py
@@ -1,11 +1,12 @@
 """Runners for different modes of operation for docstring validator."""
 from pathlib import Path
-from typing import Dict, Generator, List, Optional, Union
+from typing import Generator, List, Optional, Union
 
 from docstring_validator import diff_util
 from docstring_validator.code_parser import get_docstring
 from docstring_validator.docstring_model import Docstring
 from docstring_validator.reporter import report_errors
+from docstring_validator.validation_error import ValidationError
 
 
 def analyze_staged(
@@ -91,9 +92,7 @@ def _analyze_files(
     return report
 
 
-def _analyze_docstring(
-    raw_docstring: Optional[str],
-) -> List[Union[str, Dict[str, List[str]]]]:
+def _analyze_docstring(raw_docstring: Optional[str]) -> List[ValidationError]:
     """Checks if docstring adheres to schema."""
     docstring = Docstring(raw_docstring)
     errors = docstring.validate()

--- a/docstring_validator/validation_error.py
+++ b/docstring_validator/validation_error.py
@@ -1,4 +1,4 @@
 class ValidationError:
-    def __init__(self, code: int, text: str):
+    def __init__(self, code: str, text: str):
         self.code = code
         self.text = text

--- a/docstring_validator/validation_error.py
+++ b/docstring_validator/validation_error.py
@@ -1,4 +1,14 @@
+"""Library with classes for representing validation errors."""
+
+
 class ValidationError:
+    """Representation of single validation error.
+
+    Attributes:
+        code: error code describing validation error
+        text: description of discovered error
+    """
+
     def __init__(self, code: str, text: str):
         self.code = code
         self.text = text


### PR DESCRIPTION
Resolve problem in CI where pre-commit is using environment variables instead of staged files.

Plus resolved typing issues and missing documentation in `validation_error` module.